### PR TITLE
Update crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tblgen-alt"
-version = "0.5.0"
+name = "tblgen"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Daan Vanoverloop"]
@@ -8,7 +8,7 @@ description = "Safe Rust bindings for TableGen. Alternative updated version."
 repository = "https://github.com/edg-l/tblgen-rs-alt"
 keywords = ["llvm", "tablegen", "bindings", "wrapper"]
 categories = ["development-tools::ffi"]
-documentation = "https://mlir-rs.github.io/tblgen-rs-alt/tblgen_alt/"
+documentation = "https://mlir-rs.github.io/tblgen-rs/tblgen/"
 exclude = ["doc/"]
 
 [features]
@@ -19,9 +19,9 @@ llvm18-0 = []
 llvm19-0 = []
 
 [dependencies]
-thiserror = "2.0.9"
+thiserror = "2.0.11"
 paste = "1.0.15"
 
 [build-dependencies]
 bindgen = "0.71.1"
-cc = "1.2.7"
+cc = "1.2.9"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # tblgen
 
-[![GitHub Action](https://img.shields.io/github/actions/workflow/status/edg-l/tblgen-rs-alt/test.yaml?branch=master&style=flat-square)](https://github.com/edg-l/tblgen-rs-alt/actions?query=workflow%3Atest)
-[![Crate](https://img.shields.io/crates/v/tblgen-alt.svg?style=flat-square)](https://crates.io/crates/tblgen-alt)
-![Crates.io Total Downloads](https://img.shields.io/crates/d/tblgen-alt)
-![Crates.io License](https://img.shields.io/crates/l/tblgen-alt)
+[![GitHub Action](https://img.shields.io/github/actions/workflow/status/edg-l/tblgen-rs/test.yaml?branch=master&style=flat-square)](https://github.com/edg-l/tblgen-rs/actions?query=workflow%3Atest)
+[![Crate](https://img.shields.io/crates/v/tblgen.svg?style=flat-square)](https://crates.io/crates/tblgen)
+![Crates.io Total Downloads](https://img.shields.io/crates/d/tblgen)
+![Crates.io License](https://img.shields.io/crates/l/tblgen)
 
-This is a updated (LLVM 19) fork of https://gitlab.com/Danacus/tblgen-rs.
+Original project: https://gitlab.com/Danacus/tblgen-rs.
 Original author: Daan Vanoverloop.
+
+Thanks to the Daan for giving us access to publish to the original `tblgen` crate, we can now switch from the old `tblgen-alt` to `tblgen`. Future updates will be pushed to the original crate.
 
 This crate provides raw bindings and a safe wrapper for TableGen, a domain-specific language used by the LLVM project.
 
@@ -14,10 +16,10 @@ The goal of this crate is to enable users to develop custom TableGen backends in
 
 ## Documentation
 
-Read the documentation at https://mlir-rs.github.io/tblgen-rs-alt/tblgen_alt/.
+Read the documentation at https://mlir-rs.github.io/tblgen-rs/tblgen/.
 
 ## Supported LLVM Versions
 
-An installation of LLVM is required to use this crate. Both LLVM 16, 17 and 18 are supported and can be selected using feature flags.
+An installation of LLVM is required to use this crate. Both LLVM 16, 17, 18 and 19 are supported and can be selected using feature flags.
 
 The `TABLEGEN_<version>_PREFIX` environment variable can be used to specify a custom directory of the LLVM installation.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Crates.io License](https://img.shields.io/crates/l/tblgen)
 
 Original project: https://gitlab.com/Danacus/tblgen-rs.
+
 Original author: Daan Vanoverloop.
 
 Thanks to the Daan for giving us access to publish to the original `tblgen` crate, we can now switch from the old `tblgen-alt` to `tblgen`. Future updates will be pushed to the original crate.

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@
 //! `SourceMgr` class.
 //!
 //! ```rust
-//! use tblgen_alt::{TableGenParser, RecordKeeper};
+//! use tblgen::{TableGenParser, RecordKeeper};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! iterates over classes and defs defined in this file.
 //!
 //! ```rust
-//! use tblgen_alt::{TableGenParser, RecordKeeper};
+//! use tblgen::{TableGenParser, RecordKeeper};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
@@ -56,7 +56,7 @@
 //! By adding include paths, external TableGen files can be included.
 //!
 //! ```rust
-//! use tblgen_alt::{TableGenParser, RecordKeeper};
+//! use tblgen::{TableGenParser, RecordKeeper};
 //! use std::path::Path;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -74,7 +74,7 @@
 //! You can also pass an included filename directly.
 //!
 //! ```rust
-//! use tblgen_alt::{TableGenParser, RecordKeeper};
+//! use tblgen::{TableGenParser, RecordKeeper};
 //! use std::path::Path;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Thanks to the Daan for giving us access to publish to the original `tblgen` crate, we can now switch from the old `tblgen-alt` to `tblgen`. Future updates will be pushed to the original crate.