### PR TITLE
Upgrade to LLVM 21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ documentation = "https://mlir-rs.github.io/tblgen-rs/tblgen/"
 exclude = ["doc/"]
 
 [features]
-default = ["llvm20-0"]
+default = ["llvm21-0"]
 llvm16-0 = []
 llvm17-0 = []
 llvm18-0 = []
 llvm19-0 = []
 llvm20-0 = []
+llvm21-0 = []
 
 [dependencies]
 thiserror = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Read the documentation at https://mlir-rs.github.io/tblgen-rs/tblgen/.
 
 ## Supported LLVM Versions
 
-An installation of LLVM is required to use this crate. Both LLVM 16, 17, 18 and 19 are supported and can be selected using feature flags.
+An installation of LLVM is required to use this crate. Any of LLVM 16, 17, 18, 19, 20, and 21 are supported and can be selected using feature flags.
 
 The `TABLEGEN_<version>_PREFIX` environment variable can be used to specify a custom directory of the LLVM installation.

--- a/build.rs
+++ b/build.rs
@@ -16,8 +16,10 @@ const LLVM_MAJOR_VERSION: usize = if cfg!(feature = "llvm16-0") {
     18
 } else if cfg!(feature = "llvm19-0") {
     19
-} else {
+} else if cfg!(feature = "llvm20-0") {
     20
+} else {
+    21
 };
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 //! # Supported LLVM Versions
 //!
 //! An installation of LLVM is required to use this crate.
-//! The versions of LLVM currently supported are 16.x.x (default) and 17.x.x.
-//! Different LLVM version can be selected using features flags (llvm16-0 or
-//! llvm17-0).
+//! The versions of LLVM currently supported are 16.x.x, 17.x.x, 18.x.x,
+//! 19.x.x, 20.x.x, and 21.x.x. Different LLVM version can be selected using
+//! features flags (e.g., `llvm16-0` or `llvm17-0`).
 //!
 //! The `TABLEGEN_<version>_PREFIX` environment variable can be used to specify
 //! a custom directory of the LLVM installation.
@@ -62,7 +62,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
 //!     .add_source(r#"include "mlir/IR/OpBase.td""#)?
-//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_200_PREFIX")?))
+//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_210_PREFIX")?))
 //!     .parse()?;
 //! let i32_def = keeper.def("I32").expect("has I32 def");
 //! assert!(i32_def.subclass_of("I"));
@@ -80,7 +80,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let keeper: RecordKeeper = TableGenParser::new()
 //!     .add_source_file("mlir/IR/OpBase.td")
-//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_200_PREFIX")?))
+//!     .add_include_directory(&format!("{}/include", std::env::var("TABLEGEN_210_PREFIX")?))
 //!     .parse()?;
 //! let i32_def = keeper.def("I32").expect("has I32 def");
 //! assert!(i32_def.subclass_of("I"));

--- a/src/record_keeper.rs
+++ b/src/record_keeper.rs
@@ -10,7 +10,7 @@
 
 use std::marker::PhantomData;
 
-#[cfg(any(feature = "llvm18-0", feature = "llvm19-0", feature = "llvm20-0"))]
+#[cfg(any(feature = "llvm18-0", feature = "llvm19-0", feature = "llvm20-0", feature = "llvm21-0"))]
 use crate::error::TableGenError;
 #[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
 use crate::error::{SourceLocation, TableGenError, WithLocation};

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-llvm_version=20
+llvm_version=21
 
 brew update
 brew install llvm@$llvm_version
 
 llvm_prefix=$(brew --prefix llvm@$llvm_version)
 
-echo TABLEGEN_200_PREFIX=$llvm_prefix >>$GITHUB_ENV
+echo TABLEGEN_210_PREFIX=$llvm_prefix >>$GITHUB_ENV
 echo PATH=$llvm_prefix/bin:$PATH >>$GITHUB_ENV
 echo LIBRARY_PATH=$llvm_prefix/lib:$LIBRARY_PATH >>$GITHUB_ENV
 echo LD_LIBRARY_PATH=$llvm_prefix/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV


### PR DESCRIPTION
`cargo test` passes at least. I also updated `setup.sh` although I am not on a Mac.

Will edit/update when I've verified this works end-to-end with Melior.

I don't know if this warrants a version bump as #25 did (seems like the maintainer's call)